### PR TITLE
Add exec() builtin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test:
 	${RUN} -no-write samples/io.ink
 	${RUN} -isolate samples/io.ink
 	${RUN} -isolate samples/pingpong.ink
+	${RUN} -no-exec samples/exec.ink
 	# test -eval flag
 	${RUN} -eval "log:=load('samples/std').log,f:=x=>()=>log('Eval test: '+x),f('passed!')()"
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ run:
 		samples/pingpong.ink \
 		samples/undefinedme.ink \
 		samples/error.ink \
+		samples/exec.ink \
 		samples/prompt.ink
 
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -162,6 +162,7 @@ These are the right primitives, but we can build much more sophisticated systems
 - `wait(number, callback)`: Call the callback function after at least the given number of seconds has elapsed.
 - `rand() => number`: a pseudorandom floating point number in interval `[0, 1)`.
 - `time() => number`: number of seconds in floating point in UNIX epoch.
+- `exec(string, [list], string, callback) => callback`: Exec the command at a given path with given arguments, with a given stdin, call given callback with stdout when exited.
 
 ### Math
 
@@ -173,9 +174,9 @@ These are the right primitives, but we can build much more sophisticated systems
 
 ### Type casts and utilities (implemented as native functions)
 
-- `string(any) => string`: convert type to string
-- `number(any) => number`: convert type to number
-- `point(string) => number`: take the first byte (i.e. ASCII value) of the string and return its numerical value
+- `string(any) => string`: Convert type to string
+- `number(any) => number`: Convert type to number
+- `point(string) => number`: Take the first byte (i.e. ASCII value) of the string and return its numerical value
 - `char(number) => string`: reverse of `point()`. Note that behavior for values above 255 (full Unicode values) is undefined (so far).
 - `len(composite) => number`: length of a list, string, or list-like composite value (equal to the number of keys on the composite or list value)
 - `keys(composite) => list<string>`: list of keys of the given composite

--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@
     - It seems helpful to think of it as a constraint system on the runtime, instead of as something that’s an attribute of the runtime execution itself. I like the Haskell approach of having definition / type declarations separate from the imperative flow definition/syntax itself. Also look at how Haskell / Erlang / Clojure / other functional languages do type annotation, and keep in mind that while Ink is functional flavor it should still feel great in imperative / OO style.
     - Since Ink has no implicit casts, this seems like it'll be straightforward to infer most variable types from their declaration (what they're bound to in the beginning) and recurse up the tree. So to compute "what's the type of this expression?" the type checker will recursively ask its children for their types, and assuming none of them return an error, we can define a `func (n Node) TypeCheck() (Type, error)` that recursively descends to type check an entire AST node from the top. We can expose this behind an `ink -type-check <file>.ink` flag.
     - To support Ink's way of error handling and signaling (returning null data values), the type system must support sum types, i.e. `number | ()`
+- [ ] Promise / Futures system for abstracting over asynchronous control flow.
 - [ ] Should study event systems / event loop models like libuv and Tokio more, especially in light of Golang's strange Erlangy processes / green threads model.
 - [ ] Add to GitHub Linguist: https://github.com/github/linguist
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,5 @@
 # Todo items
 
-
 ## Interpreter
 
 - [ ] Set up Travis CI for Ink: for now, just run `make run && make test`, and pass/fail on the exit value.

--- a/cmd/ink.go
+++ b/cmd/ink.go
@@ -40,7 +40,8 @@ func main() {
 	noRead := flag.Bool("no-read", false, "Silently fail all read operations")
 	noWrite := flag.Bool("no-write", false, "Silently fail all write operations")
 	noNet := flag.Bool("no-net", false, "Silently fail all access to local network")
-	isolate := flag.Bool("isolate", false, "Isolate all system operations: read, write, net")
+	noExec := flag.Bool("no-exec", false, "Silently fail all exec calls")
+	isolate := flag.Bool("isolate", false, "Isolate all system operations: read, write, net, exec")
 
 	// cli arguments
 	verbose := flag.Bool("verbose", false, "Log all interpreter debug information")
@@ -75,6 +76,7 @@ func main() {
 			Read:  !*noRead && !*isolate,
 			Write: !*noWrite && !*isolate,
 			Net:   !*noNet && !*isolate,
+			Exec:  !*noExec && !*isolate,
 		},
 		Debug: ink.DebugConfig{
 			Lex:   *debugLexer || *verbose,

--- a/pkg/ink/eval.go
+++ b/pkg/ink/eval.go
@@ -973,6 +973,7 @@ type PermissionsConfig struct {
 	Read  bool
 	Write bool
 	Net   bool
+	Exec  bool
 }
 
 // DebugConfig defines any debugging flags referenced at runtime

--- a/samples/exec.ink
+++ b/samples/exec.ink
@@ -25,9 +25,10 @@ exec('/bin/echo', ['Hello, Echo!'], '', s => out(s))
 log('See: lovin-pasta')
 exec('cat', [], 'lovin-pasta', s => out(s))
 
-` closes before execution `
+` closes immediately after exec `
 (
-	close := exec('sleep', ['10'], '', s => log('YOU SHOULD NEVER SEE THIS'))
+	log('Should close immediately after exec safely (may not run):')
+	close := exec('sleep', ['10'], '', s => log('Closed immediately after exec safely!'))
 	close()
 
 	` multiple closes do not fail `

--- a/samples/exec.ink
+++ b/samples/exec.ink
@@ -1,0 +1,61 @@
+` demonstration of Ink calling into other
+	programs with exec(), assumes POSIX system `
+
+std := load('std')
+
+log := std.log
+
+` runs without problems `
+log('See: Hello, World!')
+exec('echo', ['Hello, World!'], '', s => out(s))
+
+` swallows stdout correctly `
+log('See: nothing')
+exec('echo', ['Hello, World!'], '', s => ())
+
+` sets args correctly `
+log('See: Goodbye, World!')
+exec('echo', ['Goodbye,', 'World!'], '', s => out(s))
+
+` runs commands at full paths `
+log('See: Hello, Echo!')
+exec('/bin/echo', ['Hello, Echo!'], '', s => out(s))
+
+` interprets stdin correctly `
+log('See: lovin-pasta')
+exec('cat', [], 'lovin-pasta', s => out(s))
+
+` closes before execution `
+(
+	close := exec('sleep', ['10'], '', s => log('YOU SHOULD NEVER SEE THIS'))
+	close()
+
+	` multiple closes do not fail `
+	close()
+	close()
+)
+
+` closes during execution `
+(
+	log('Should close during execution safely:')
+	close := exec('sleep', ['5'], '', s => log('Closed during execution safely!'))
+	wait(1, () => close())
+
+	` multiple closes do not fail `
+	wait(2, () => close())
+)
+
+` closes after execution `
+(
+	log('Should exit safely, then close:')
+	close := exec('sleep', ['1'], '', s => log('Exited safely!'))
+	wait(2, () => (
+		close()
+		log('Closed!')
+
+		` multiple closes do not fail `
+		close()
+		close()
+		close()
+	))
+)

--- a/utils/ink.vim
+++ b/utils/ink.vim
@@ -74,6 +74,7 @@ syntax keyword inkBuiltin req contained
 syntax keyword inkBuiltin rand contained
 syntax keyword inkBuiltin time contained
 syntax keyword inkBuiltin wait contained
+syntax keyword inkBuiltin exec contained
 
 syntax keyword inkBuiltin sin contained
 syntax keyword inkBuiltin cos contained


### PR DESCRIPTION
Rather than building a complex FFI, Ink will conform to classic UNIX ideas
and exec() child processes to communicate with and compose on other programs.